### PR TITLE
Fix ethereum mempool/address index consistency

### DIFF
--- a/bchain/coins/eth/ethrpc.go
+++ b/bchain/coins/eth/ethrpc.go
@@ -983,8 +983,49 @@ func (b *EthereumRPC) GetTransactionSpecific(tx *bchain.Tx) (json.RawMessage, er
 	return json.RawMessage(m), err
 }
 
-// GetMempoolTransactions returns transactions in mempool
+// GetMempoolTransactions returns transactions in mempool.
+//
+// Prefers `txpool_content` over `eth_getBlockByNumber("pending")` when the
+// txpool namespace is available: the pending-block view only includes
+// *executable* txs (i.e. nonce = last_confirmed + 1 and contiguous), so
+// queued txs with nonce gaps are invisible to callers. This caused blockbook
+// address-level responses to "forget" pending txs that geth still held, while
+// per-tx lookups continued to return them — visible inconsistency to API
+// consumers.
 func (b *EthereumRPC) GetMempoolTransactions() ([]string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), b.Timeout)
+	defer cancel()
+
+	// Each tx entry only needs the `hash` field; the full RPC response can be
+	// large so we deserialize into a narrow type to keep memory bounded.
+	type poolTx struct {
+		Hash string `json:"hash"`
+	}
+	var content struct {
+		Pending map[string]map[string]poolTx `json:"pending"`
+		Queued  map[string]map[string]poolTx `json:"queued"`
+	}
+	if err := b.RPC.CallContext(ctx, &content, "txpool_content"); err == nil {
+		txids := make([]string, 0, len(content.Pending)+len(content.Queued))
+		for _, byNonce := range content.Pending {
+			for _, tx := range byNonce {
+				if tx.Hash != "" {
+					txids = append(txids, tx.Hash)
+				}
+			}
+		}
+		for _, byNonce := range content.Queued {
+			for _, tx := range byNonce {
+				if tx.Hash != "" {
+					txids = append(txids, tx.Hash)
+				}
+			}
+		}
+		return txids, nil
+	}
+
+	// txpool namespace not available — fall back to the pending block (omits
+	// queued txs, but better than nothing).
 	raw, err := b.getBlockRaw("pending", 0, false)
 	if err != nil {
 		return nil, err

--- a/configs/coins/ethereum.json
+++ b/configs/coins/ethereum.json
@@ -61,7 +61,7 @@
                 "address_aliases": true,
                 "eip1559Fees": true,
                 "mempoolTxTimeoutHours": 48,
-                "queryBackendOnMempoolResync": false,
+                "queryBackendOnMempoolResync": true,
                 "fiat_rates": "coingecko",
                 "fiat_rates_vs_currencies": "AED,ARS,AUD,BDT,BHD,BMD,BRL,CAD,CHF,CLP,CNY,CZK,DKK,EUR,GBP,HKD,HUF,IDR,ILS,INR,JPY,KRW,KWD,LKR,MMK,MXN,MYR,NGN,NOK,NZD,PHP,PKR,PLN,RUB,SAR,SEK,SGD,THB,TRY,TWD,UAH,USD,VEF,VND,ZAR,BTC,ETH",
                 "fiat_rates_params": "{\"coin\": \"ethereum\",\"platformIdentifier\": \"ethereum\",\"platformVsCurrency\": \"eth\",\"periodSeconds\": 900}",


### PR DESCRIPTION
## Summary

Address-level API responses silently drop pending txs that blockbook's in-memory mempool has evicted, while per-tx responses still return them from the backend. This produces visible inconsistency to API consumers (e.g. wallets showing `/api/v2/tx/{hash}` as pending but `/api/v2/address/{addr}` returning `unconfirmedTxs: 0`).

## Root causes

1. **`MempoolEthereumType.Resync()`** enforces a 48h timeout eviction on its `txEntries` / `addrDescToTx` maps. Without `queryBackendOnMempoolResync`, nothing re-populates them — long-lived pending txs disappear from address queries even though the backend still holds them.

2. **`GetMempoolTransactions()`** sources from `eth_getBlockByNumber("pending")`, which only returns *executable* pending txs (nonce = last\_confirmed + 1 and contiguous). Nonce-gap txs in the queued pool are invisible, so even with re-sync enabled they can't be re-hydrated.

## Changes

- `configs/coins/ethereum.json`: flip `queryBackendOnMempoolResync` to `true`.
- `bchain/coins/eth/ethrpc.go`: prefer `txpool_content` (both pending and queued buckets) when the txpool namespace is available; fall back to the pending-block view otherwise.

Erigon is started with `--http.api "eth,net,web3,debug,txpool"` in the current ethereum.json config, so the new RPC path is available out of the box.

## Test plan

- [ ] Deploy to a blockbook-eth instance with long-lived pending txs in the address's mempool.
- [ ] `GET /api/v2/address/{addr}` → confirm `unconfirmedTxs` reflects the geth mempool count.
- [ ] `GET /api/v2/address/{addr}?details=txs` → confirm pending txs appear at the top of `transactions`.
- [ ] `GET /api/v2/tx/{hash}` for a nonce-gap queued tx → should still return pending status.

🤖 Generated with [Claude Code](https://claude.com/claude-code)